### PR TITLE
Fix doc type related issue for index page

### DIFF
--- a/templates/_document.liquid
+++ b/templates/_document.liquid
@@ -17,7 +17,7 @@
 
     <div class="doc-type-wrap">
       <div class="doc-type {{ document.type | downcase | split: " " | join: "-" }}">
-      {{ document.type }}
+      {{ document.doctype }}
       </div>
     </div>
   </div>


### PR DESCRIPTION
In XML to HTML renderer we are using some liquid templates to render the html page for any collection, but currently we are showing the `doctype` attributes, which is always standard.

This commit changes this to display the correct doc type in the listing page. Currently we don't have any specific styling for all doc type, so we aren't leaving the css class as it is, but we might want to adjust in the near future.

Related: https://github.com/metanorma/metanorma-cli/issues/250

**NOTE**:  This changes will effect every collection that is using the default templates to from `standard` to the correct doc type, if that's don't desirable then please use it with precaution.

//cc: @ronaldtse, @andrew2net 