### PR TITLE
Escape bare & in Bibcollection#to_xml to prevent invalid XML: https://github.com/metanorma/isodoc/issues/785

### DIFF
--- a/lib/relaton/bibcollection.rb
+++ b/lib/relaton/bibcollection.rb
@@ -32,8 +32,8 @@ module Relaton
 
     # @param source [Nokogiri::XML::Element]
     def self.from_xml(source)
-      title = find_text("./relaton-collection/title", source)
-      author = find_text(
+      title = find_html("./relaton-collection/title", source)
+      author = find_html(
         "./relaton-collection/contributor[role/@type='author']/organization/"\
         "name", source
       )

--- a/lib/relaton/bibcollection.rb
+++ b/lib/relaton/bibcollection.rb
@@ -61,10 +61,10 @@ module Relaton
                         end
 
       ret = "<relaton-collection #{collection_type}>"
-      ret += "<title>#{title}</title>" if title
+      ret += "<title>#{xml_escape(title)}</title>" if title
       if author
         ret += "<contributor><role type='author'/><organization><name>"\
-        "#{author}</name></organization></contributor>"
+        "#{xml_escape(author)}</name></organization></contributor>"
       end
       unless items.empty?
         items.each do |item|
@@ -133,6 +133,14 @@ module Relaton
                else new_bib_item_class(item)
                end
       end
+    end
+
+    # Escape bare & in content for XML serialization, leaving already-encoded
+    # entity references (&amp;, &#123;, &#x1f;) and inline markup (<em> etc.)
+    # untouched. This prevents invalid XML when plain-text values (e.g. from
+    # YAML) contain literal ampersands.
+    def xml_escape(str)
+      str.gsub(/&(?![a-zA-Z][a-zA-Z0-9]*;|#[0-9]+;|#x[0-9a-fA-F]+;)/, "&amp;")
     end
   end
 end

--- a/lib/relaton/element_finder.rb
+++ b/lib/relaton/element_finder.rb
@@ -6,6 +6,10 @@ module Relaton
       find(xpath, element)&.text
     end
 
+    def find_html(xpath, element = nil)
+      find(xpath, element)&.inner_html
+    end
+
     def find(xpath, element = nil)
       (element || document).at(apply_namespace(xpath))
     end

--- a/spec/assets/index-with-markup.xml
+++ b/spec/assets/index-with-markup.xml
@@ -1,0 +1,23 @@
+<relaton-collection xmlns="http://riboseinc.com/isoxml">
+  <title>Use of <strong>ActualText</strong> &amp; <strong>Reference</strong> structure elements</title>
+  <contributor>
+    <role type="author"/>
+    <organization>
+      <name>Acme &amp; Co</name>
+    </organization>
+  </contributor>
+  <relation type='partOf'>
+    <bibdata type='standard'>
+      <title>Sample doc title</title>
+      <uri>http://example.org/sample.pdf</uri>
+      <docidentifier primary="true">EX 1</docidentifier>
+      <date type='published'>
+        <on>2026-01-01</on>
+      </date>
+      <status><stage>Published</stage></status>
+      <ext>
+        <technical-committee>TC EX</technical-committee>
+      </ext>
+    </bibdata>
+  </relation>
+</relaton-collection>

--- a/spec/relaton/cli/xml_to_html_renderer_spec.rb
+++ b/spec/relaton/cli/xml_to_html_renderer_spec.rb
@@ -31,6 +31,29 @@ RSpec.describe Relaton::Cli::XmlToHtmlRenderer do
       end
     end
 
+    context "with markup and entities in the collection title and author" do
+      let(:html) do
+        renderer.render(File.read("spec/assets/index-with-markup.xml"))
+      end
+
+      it "preserves <strong> markup and &amp; in the coverpage title" do
+        expect(html).to include(
+          '<span class="title-first">Use of <strong>ActualText</strong> ' \
+          "&amp; <strong>Reference</strong> structure elements</span>",
+        )
+      end
+
+      it "strips inline tags but keeps &amp; in <head><title>" do
+        head_title = html[/<title>([^<]*(?:<(?!\/title)[^<]*)*)<\/title>/m, 1]
+        expect(head_title).to include("&amp;")
+        expect(head_title).not_to include("<strong>")
+      end
+
+      it "preserves &amp; in the rendered author" do
+        expect(html).to include("Acme &amp; Co")
+      end
+    end
+
     context "with a document containing other collections" do
       let(:html) do
         renderer.render(File.read("spec/assets/with-collections.xml"))

--- a/templates/_index.liquid
+++ b/templates/_index.liquid
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML>
 <html>
   <head>
-    <title>{{ title }}</title>
+    <title>{{ title | strip_html }}</title>
     <style>
 <!--
 {{ css }}


### PR DESCRIPTION
## Problem

`Bibcollection#to_xml` writes the collection `title` and `author` directly into XML without escaping. When these values come from YAML (e.g. `name: "A test & playground ..."`), the output is a bare `&` character, which is invalid XML.

libxml2 responds with a **FATAL** `xmlParseEntityRef: no name` error and enters recovery mode. In recovery mode it silently drops **all** subsequent `&amp;` entity references in the same document — so every individual bibitem title that contains `&amp;` also loses its `&` in the generated HTML output. This is what surfaces as the bug reported in metanorma/isodoc#785.

## Root cause trace

```
YAML: name: "A test & playground …"
  ↓ to_xml (unescaped)
documents.xml: <title>A test & playground …</title>   ← invalid XML
  ↓ Nokogiri::XML parse (libxml2 recovery mode)
  FATAL: xmlParseEntityRef: no name
  → bare & dropped from collection title
  → ALL subsequent &amp; in document dropped as collateral damage
    → individual doc <title>…<em>Test</em> &amp; <strong>Play</strong>…</title>
       becomes  <em>Test</em>  <strong>Play</strong>  (entity gone, two spaces left)
  ↓ find_html / to_h
  ↓ Liquid template
index.html: "A test  playground …"  and  "<em>Test</em>  <strong>Playground</strong>"
```

## Fix

Add a private `xml_escape` helper that escapes only **unencoded** `&` — not already-encoded entity references (`&amp;`, `&#123;`, `&#x1f;`) — and leaves inline markup tags (`<em>`, `<strong>`, etc.) untouched. This means values from YAML are safe, and HTML fragments round-tripped via `find_html` pass through unchanged.

## Relationship to the earlier `find_text → find_html` commit

The preceding commit on this branch (`8ed16f5`) fixed the **read** path (use `inner_html` to preserve markup when re-reading the collection title from XML). This commit fixes the **write** path (escape before inserting into XML). Both are needed: without the write-path fix the XML is never valid, so the read-path fix cannot help.

## Verification

After applying the fix, regenerating the metanorma-pdfa test collection produces:

```xml
<!-- documents.xml — collection title now valid XML -->
<title>A test &amp; playground PDFa document from YAML</title>
```

```html
<!-- index.html — collection title -->
<span class="title-first">A test &amp; playground PDFa document from YAML</span>

<!-- index.html — individual doc title, &amp; now preserved -->
<a href="./documents/test-pdfa.html"><em>Test</em> &amp; <strong>Playground</strong> PDFa Document from ADOC <tt>H1</tt></a>
```

Refs: metanorma/isodoc#785: https://github.com/metanorma/isodoc/issues/785

🤖 Generated with [Claude Code](https://claude.com/claude-code)
